### PR TITLE
feat: 套餐计费页改版 + Codex/Claude Desktop Gateway 配置指南

### DIFF
--- a/pages/getting-started/_meta.js
+++ b/pages/getting-started/_meta.js
@@ -22,6 +22,7 @@ export default {
     title: 'OpenAI Codex'
   },
   'codex-installation': '安装和配置',
+  'codex-desktop': 'Desktop 客户端配置',
   'gemini-core': {
     type: 'separator',
     title: 'Google Gemini CLI'

--- a/pages/getting-started/codex-desktop.mdx
+++ b/pages/getting-started/codex-desktop.mdx
@@ -1,0 +1,251 @@
+---
+title: Desktop 客户端配置
+description: Codex Desktop（GUI 客户端）连接到 OpenAI 兼容 Gateway 的完整配置指南
+---
+
+import { Callout, Tabs } from 'nextra/components'
+
+# Codex Desktop 客户端配置指南
+
+本指南面向已安装 **Codex Desktop**（GUI 客户端）的用户，帮你把桌面端连接到 OpenAI 兼容网关 `https://claude-code.club/openai`。如果你只用 Codex CLI，请优先参考 [安装和配置](/getting-started/codex-installation)。
+
+## 1. 前置条件
+
+- 已安装 Codex Desktop（如未安装，请先参考 [安装和配置](/getting-started/codex-installation) 第 1 节，或访问 [Codex 官方文档](https://github.com/openai/codex)）
+- 已获取有效 API Key（参考 [获取 API Key](/getting-started/get-api-key)）
+- 不要使用已经在聊天、截图或仓库中暴露过的旧 Key；泄露后应立即作废并重建
+
+## 2. Desktop 与 CLI 的配置关系
+
+Codex Desktop 与 Codex CLI **共用**同一组配置文件：
+
+| 文件 | 路径 | 作用 |
+|------|------|------|
+| `config.toml` | `~/.codex/config.toml` | 模型与网关定义 |
+| `auth.json` | `~/.codex/auth.json` | 认证密钥 |
+
+<Callout type="info">
+  Desktop 与 CLI 的配置共享，但 **重启策略** 和 **环境变量读取范围** 不同：Desktop 是图形进程，需要完全退出再启动；macOS 上 GUI 应用读不到 `~/.zshrc` 中的环境变量，必须用 `launchctl setenv`。这两点是本页的重点。
+</Callout>
+
+## 3. 最小可用配置
+
+如果你之前没配置过 `~/.codex/`，按下面步骤一次完成。如果已有配置，请保留其它配置块，仅确保下面这些键值存在且正确。
+
+### 3.1 创建 / 打开配置目录
+
+<Tabs items={['macOS / Linux', 'Windows (PowerShell)']}>
+  <Tabs.Tab>
+    ```bash
+    mkdir -p ~/.codex
+    open ~/.codex
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```powershell
+    New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex"
+    explorer "$env:USERPROFILE\.codex"
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+### 3.2 备份原文件（如果已存在）
+
+<Tabs items={['macOS / Linux', 'Windows (PowerShell)']}>
+  <Tabs.Tab>
+    ```bash
+    cp ~/.codex/config.toml ~/.codex/config.toml.bak 2>/dev/null
+    cp ~/.codex/auth.json   ~/.codex/auth.json.bak   2>/dev/null
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```powershell
+    Copy-Item "$env:USERPROFILE\.codex\config.toml" "$env:USERPROFILE\.codex\config.toml.bak" -ErrorAction SilentlyContinue
+    Copy-Item "$env:USERPROFILE\.codex\auth.json"   "$env:USERPROFILE\.codex\auth.json.bak"   -ErrorAction SilentlyContinue
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+### 3.3 编辑 `config.toml`
+
+<Tabs items={['macOS / Linux', 'Windows (PowerShell)']}>
+  <Tabs.Tab>
+    ```bash
+    nano ~/.codex/config.toml
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```powershell
+    notepad "$env:USERPROFILE\.codex\config.toml"
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+写入或合并以下内容：
+
+```toml
+model_provider = "club"
+model = "gpt-5.5"
+model_reasoning_effort = "high"
+preferred_auth_method = "apikey"
+disable_response_storage = true
+
+[model_providers.club]
+name = "Claude Code Club OpenAI Gateway"
+base_url = "https://claude-code.club/openai"
+wire_api = "responses"
+requires_openai_auth = true
+env_key = "OPENAI_API_KEY"
+```
+
+<Callout type="info">
+  字段含义详解（如 `wire_api`、`requires_openai_auth` 等）请参考 [安装和配置](/getting-started/codex-installation) 第 2 节。
+</Callout>
+
+### 3.4 编辑 `auth.json`
+
+<Tabs items={['macOS / Linux', 'Windows (PowerShell)']}>
+  <Tabs.Tab>
+    ```bash
+    nano ~/.codex/auth.json
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```powershell
+    notepad "$env:USERPROFILE\.codex\auth.json"
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+写入以下结构，把占位符换成你的真实 API Key：
+
+```json
+{
+  "auth_mode": "apikey",
+  "OPENAI_API_KEY": "你的APIKey"
+}
+```
+
+<Callout type="warning">
+  `auth.json` 会以**明文**保存真实 API Key。不要把该文件截图、上传到 GitHub 或发给他人。如果 Key 已经泄露，应立刻作废并重新生成。
+</Callout>
+
+## 4. 重启 Codex Desktop
+
+配置改完后，**只关闭窗口不会让配置生效**——必须完全退出 Codex Desktop 进程再重新打开。
+
+<Tabs items={['macOS / Linux', 'Windows (PowerShell)']}>
+  <Tabs.Tab>
+    1. 在菜单栏点击 `Codex` → `Quit Codex`，或按 `Cmd + Q`
+    2. 打开 **Activity Monitor**（活动监视器），搜索 `Codex`，确认相关进程（包括 `Codex Helper`）已全部退出
+    3. 重新启动 Codex Desktop
+    4. 打开任意项目，发送一条简单请求验证配置生效
+  </Tabs.Tab>
+  <Tabs.Tab>
+    1. 关闭 Codex Desktop 主窗口
+    2. 打开**任务管理器**（`Ctrl + Shift + Esc`），在「进程」中找到所有 `Codex` 相关条目，逐个结束
+    3. 重新启动 Codex Desktop
+    4. 打开任意项目，发送一条简单请求验证配置生效
+  </Tabs.Tab>
+</Tabs>
+
+<Callout type="warning">
+  如果只点了窗口右上角的关闭按钮，进程往往仍在后台运行，配置文件的改动不会被读取。务必确认进程已经完全退出。
+</Callout>
+
+## 5. macOS：launchctl 环境变量（可选）
+
+如果你的某些 OpenAI 兼容 SDK 或 Codex Desktop 的扩展需要从环境变量读取 Key，且只想在 GUI 进程中生效，可以使用 `launchctl setenv`。
+
+<Callout type="info">
+  如果你已经通过 `config.toml` + `auth.json` 完成配置并能正常对话，**本节可跳过**。
+</Callout>
+
+```bash
+launchctl setenv OPENAI_BASE_URL "https://claude-code.club/openai"
+launchctl setenv OPENAI_API_KEY  "你的APIKey"
+```
+
+<Callout type="warning">
+  GUI 应用（包括 Codex Desktop）**不会**读取 `~/.zshrc` / `~/.bashrc` 中的 `export`。这是 macOS 终端 shell 与 Aqua GUI 之间的环境隔离造成的——所以才需要 `launchctl setenv`。重启系统后 `launchctl setenv` 会失效，如需持久化请配合 LaunchAgents。
+</Callout>
+
+如果你只在终端里使用 Codex CLI，参考 [安装和配置](/getting-started/codex-installation) 第 3 节即可。
+
+## 6. 连通性测试（可选诊断）
+
+如果想在启动 Desktop 前先确认网关和 Key 是否可用，可以用 `curl` 直接调用 OpenAI Responses 风格接口。
+
+<Tabs items={['macOS / Linux', 'Windows (PowerShell)']}>
+  <Tabs.Tab>
+    ```bash
+    curl -sS "https://claude-code.club/openai/v1/responses" \
+      -H "Authorization: Bearer 你的APIKey" \
+      -H "Content-Type: application/json" \
+      -d '{"model":"gpt-5.5","input":"你好，回复一句：测试成功"}'
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```powershell
+    $body = @{
+      model = "gpt-5.5"
+      input = "你好，回复一句：测试成功"
+    } | ConvertTo-Json -Depth 10
+
+    curl.exe -sS "https://claude-code.club/openai/v1/responses" `
+      -H "Authorization: Bearer 你的APIKey" `
+      -H "Content-Type: application/json" `
+      -d $body
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+如果返回 JSON 中包含模型回复内容，说明网关和 Key 都没问题；此时若 Desktop 仍连不上，问题大概率在 `config.toml` 字段或进程未重启。
+
+## 7. 故障排查
+
+| 现象 | 处理方式 |
+|------|---------|
+| `Invalid API key` | `auth.json` 或环境变量里的 Key 错误、过期、被禁用，重新生成并替换 |
+| 仍然访问旧网关 | 检查 `config.toml` 中 `base_url` 是否还是旧的 `https://cc.ai-code.club`，改为 `https://claude-code.club/openai` |
+| 模型不可用 | `model` 值不被当前网关支持，换成平台支持的模型，例如 `gpt-5.5` |
+| `JSON` 格式错误 | `auth.json` 必须是合法 JSON，最后一项后面不能多逗号 |
+| `TOML` 格式错误 | `config.toml` 的字符串要用英文双引号；配置块 `[model_providers.club]` 拼写不要错 |
+| 改完不生效 | 完全退出 Codex Desktop（参见第 4 节），必要时重启系统 |
+
+## 8. 恢复默认配置
+
+如果配置改坏了，可以从备份文件恢复：
+
+<Tabs items={['macOS / Linux', 'Windows (PowerShell)']}>
+  <Tabs.Tab>
+    ```bash
+    cp ~/.codex/config.toml.bak ~/.codex/config.toml
+    cp ~/.codex/auth.json.bak   ~/.codex/auth.json
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```powershell
+    Copy-Item "$env:USERPROFILE\.codex\config.toml.bak" "$env:USERPROFILE\.codex\config.toml" -Force
+    Copy-Item "$env:USERPROFILE\.codex\auth.json.bak"   "$env:USERPROFILE\.codex\auth.json"   -Force
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+恢复后同样需要按第 4 节完全重启 Codex Desktop。
+
+## 9. 安全规范
+
+<Callout type="warning">
+  - `auth.json` 中的 `OPENAI_API_KEY` 等同于密码，不要写入公开文档、截图或 Git 仓库
+  - `config.toml` / `auth.json` / 其他导出文件可能包含明文 Key，仅在可信设备上短期保存
+  - 团队共享配置时，只共享步骤和占位符，不共享真实密钥
+  - 如果 Key 曾出现在聊天、截图、日志或公开仓库中，应立即作废并重新生成
+</Callout>
+
+## 10. 参考资料
+
+- [OpenAI Codex 安装和配置](/getting-started/codex-installation) — Codex CLI 视角的完整安装指南
+- [获取 API Key](/getting-started/get-api-key) — claude-code.club API Key 申请流程
+- [配置 Base URL 和 Auth Token](/getting-started/faq/config-baseurl-authtoken) — 环境变量 / 配置文件 / 项目级配置三种方式
+- [Codex 官方仓库](https://github.com/openai/codex)

--- a/pages/getting-started/faq/_meta.js
+++ b/pages/getting-started/faq/_meta.js
@@ -8,4 +8,5 @@ export default {
   'fetch-websearch-alternatives': 'fetch/web_search 替代方案',
   'use-in-ide': '在 IDE 中使用 Claude Code',
   'connect-openai-model': '连接 GPT 大模型',
+  'claude-desktop-gateway': 'Claude Desktop 第三方 Gateway 配置',
 }

--- a/pages/getting-started/faq/claude-desktop-gateway.mdx
+++ b/pages/getting-started/faq/claude-desktop-gateway.mdx
@@ -1,0 +1,224 @@
+---
+title: Claude Desktop 第三方 Gateway 配置
+description: 在 Claude Desktop（GUI 客户端）中配置兼容 Anthropic Messages API 的第三方 Gateway，Windows 与 macOS 完整操作指南
+---
+
+import { Callout, Tabs } from 'nextra/components'
+
+# Claude Desktop 第三方 Gateway 配置指南
+
+本指南面向已安装 **Claude Desktop**（GUI 客户端）的用户，帮你把桌面端连接到兼容 Anthropic Messages API 的第三方 Gateway，本文以 `https://claude-code.club/api` 为例。
+
+如果你只用 Claude Code CLI，请优先参考 [配置 Base URL 和 Auth Token](/getting-started/faq/config-baseurl-authtoken)。
+
+## 1. 核心概念与地址选择
+
+Claude Desktop 的 **第三方推理配置** 用于把模型请求转发到自定义 Gateway。该 Gateway 必须兼容 Anthropic Messages API；它**不同于** OpenAI 风格的 `/v1/responses` 接口。
+
+| 配置项 | 推荐值 / 说明 |
+|---|---|
+| Gateway base URL | `https://claude-code.club/api` |
+| 鉴权方式 | `bearer`（即 `Authorization: Bearer <你的 API Key>`） |
+| 额外请求头 | 一般留空，除非服务商明确要求 |
+
+<Callout type="warning">
+**不要混用地址。** Claude Desktop 的 Gateway 配置应使用 Anthropic 兼容地址（例如 `https://claude-code.club/api`）；不要把 OpenAI / Codex 风格的地址（如 `https://claude-code.club/openai`）填入 Claude Desktop。
+</Callout>
+
+## 2. 配置前检查清单
+
+- 已安装最新 Claude Desktop
+- 已获取有效 API Key（参考 [获取 API Key](/getting-started/get-api-key)）
+- 不要使用已经在聊天、截图或仓库中暴露过的旧 Key；泄露后应立即作废并重建
+- 能够完全退出并重新打开 Claude Desktop（第三方推理配置通常需要重启应用后生效）
+
+## 3. 图形界面配置（推荐）
+
+### 3.1 打开第三方推理配置
+
+<Tabs items={['macOS / Linux', 'Windows (PowerShell)']}>
+  <Tabs.Tab>
+    1. 打开 Claude Desktop
+    2. 菜单栏进入 `Help` → `Troubleshooting`
+    3. 开启 `Enable Developer mode`
+    4. 进入菜单 `Developer` → `Configure third-party inference`
+  </Tabs.Tab>
+  <Tabs.Tab>
+    1. 打开 Claude Desktop
+    2. 菜单栏进入 `Help` → `Troubleshooting`
+    3. 开启 `Enable Developer mode`
+    4. 进入菜单 `Developer` → `Configure third-party inference`
+  </Tabs.Tab>
+</Tabs>
+
+### 3.2 填写 Gateway Credentials
+
+| 界面字段 | 填写内容 |
+|---|---|
+| `Gateway base URL` | `https://claude-code.club/api` |
+| `Gateway API key` | 你的有效 API Key（不要在文档或截图里暴露真实值） |
+| `Gateway auth scheme` | `bearer` |
+| `Gateway extra headers` | 留空 |
+
+### 3.3 应用配置
+
+1. 优先点击 **`Apply locally`**
+2. 看到成功提示后，**完全退出** Claude Desktop
+3. 重新打开 Claude Desktop 并发送一条测试消息
+4. 如果可以正常回复，说明配置已生效
+
+<Callout type="warning">
+**完全退出**指必须确保进程已结束 —— macOS 用 Activity Monitor 检查 `Claude` 进程已退出；Windows 在任务管理器中结束所有 `Claude` 进程。仅关闭窗口往往不会让配置生效。
+</Callout>
+
+## 4. 导出备用方案
+
+如果 `Apply locally` 不生效，或需要批量给多台机器部署相同配置，可以使用 **Export** 导出系统级配置文件。
+
+<Tabs items={['macOS / Linux', 'Windows (PowerShell)']}>
+  <Tabs.Tab>
+    **macOS：导出 `.mobileconfig`**
+
+    1. 在 `Configure third-party inference` 页面点击 `Export`
+    2. 选择 `macOS configuration profile (.mobileconfig)`
+    3. 保存到本机安全位置
+    4. 双击 `.mobileconfig` 文件，按系统提示进入 `System Settings` 安装配置描述文件
+    5. 安装后完全退出并重新打开 Claude Desktop
+
+    <Callout type="warning">
+      `.mobileconfig` 可能包含明文 API Key。只在可信设备上安装，用完后妥善删除原文件。
+    </Callout>
+  </Tabs.Tab>
+  <Tabs.Tab>
+    **Windows：导出 `.reg`**
+
+    1. 在 `Configure third-party inference` 页面点击 `Export`
+    2. 选择 `Windows registry file (.reg)`
+    3. 保存到本机安全位置
+    4. 双击 `.reg` 文件，确认导入注册表
+    5. 完全退出并重新打开 Claude Desktop
+
+    <Callout type="warning">
+      `.reg` 文件可能包含明文 API Key。导入后建议立即删除该文件；不要上传到 GitHub、网盘或发给他人。
+    </Callout>
+  </Tabs.Tab>
+</Tabs>
+
+## 5. Export 菜单格式说明
+
+| 导出选项 | 用途 |
+|---|---|
+| `Windows registry file (.reg)` | Windows 推荐备用格式；导入注册表 |
+| `macOS configuration profile (.mobileconfig)` | macOS 推荐备用格式；系统配置描述文件 |
+| `Plain JSON (.json)` | 通常不直接导入，用于排查或管理系统二次处理 |
+| `Firewall allowlist (.txt)` | 防火墙白名单，**不是** Gateway 账号配置 |
+| `Copy to clipboard (redacted)` | 适合发给别人排查配置结构；敏感值会被隐藏，**不能**作为完整导入 |
+
+## 6. CLI 环境变量（可选）
+
+如果你还要在终端中使用 Claude Code CLI，可以额外配置环境变量。Claude Desktop Gateway 图形配置和 CLI 环境变量是两套入口，但建议保持同一组地址和 Key。
+
+<Tabs items={['macOS / Linux', 'Windows (PowerShell)']}>
+  <Tabs.Tab>
+    把变量写入 zsh / bash 配置：
+
+    ```bash
+    cat >> ~/.zshrc <<'EOF'
+    export ANTHROPIC_BASE_URL="https://claude-code.club/api"
+    export ANTHROPIC_AUTH_TOKEN="你的APIKey"
+    export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1"
+    EOF
+    source ~/.zshrc
+    ```
+
+    检查是否生效：
+
+    ```bash
+    echo $ANTHROPIC_BASE_URL
+    echo $ANTHROPIC_AUTH_TOKEN
+    echo $CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    在 PowerShell 中写入用户级环境变量：
+
+    ```powershell
+    [System.Environment]::SetEnvironmentVariable("ANTHROPIC_BASE_URL", "https://claude-code.club/api", "User")
+    [System.Environment]::SetEnvironmentVariable("ANTHROPIC_AUTH_TOKEN", "你的APIKey", "User")
+    [System.Environment]::SetEnvironmentVariable("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1", "User")
+    ```
+
+    设置后关闭当前 PowerShell，重新打开后检查：
+
+    ```powershell
+    echo $env:ANTHROPIC_BASE_URL
+    echo $env:ANTHROPIC_AUTH_TOKEN
+    echo $env:CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+## 7. 验证方法
+
+- Claude Desktop 能正常启动
+- 发送消息后没有出现 `authentication`、`invalid api key`、`gateway unavailable` 等错误
+- 回复速度和模型行为符合 Gateway 服务预期
+- 如果同时使用 CLI，可以运行 `echo` 命令确认环境变量值存在
+
+如果之前已经成功通过 `Apply locally` 配置并可正常对话，就说明本地 Gateway 配置已经生效。
+
+## 8. 故障排查
+
+| 现象 | 处理方式 |
+|---|---|
+| `Invalid API key` | Key 错误、过期、被禁用或不属于该 Gateway。重新生成并填写 |
+| 连接失败 / `Gateway unavailable` | 检查网络、Gateway base URL 是否为 `https://claude-code.club/api`，确认没有多填 `/v1/messages` |
+| 模型不可用 | 当前账号或 Gateway 不支持请求的模型；联系服务商确认可用模型 |
+| `Apply locally` 后不生效 | 完全退出 Claude Desktop 后重启；Windows 可改用 `.reg`，macOS 可改用 `.mobileconfig` |
+| 配置文件导入后仍失败 | 重新打开配置页检查 Base URL、auth scheme、extra headers 是否正确 |
+
+## 9. 恢复默认配置
+
+<Tabs items={['macOS / Linux', 'Windows (PowerShell)']}>
+  <Tabs.Tab>
+    如果通过 `.mobileconfig` 安装了配置描述文件，在 `System Settings` 中找到 `Profiles` / `Device Management`，删除对应 Claude 配置描述文件，然后重启 Claude Desktop。
+
+    <Callout type="info">
+      不同 macOS 版本入口名称可能略有差异（System Preferences / System Settings / Profiles）。
+    </Callout>
+  </Tabs.Tab>
+  <Tabs.Tab>
+    如果之前通过注册表策略写入配置，在 PowerShell 中删除策略项，然后重启 Claude Desktop：
+
+    ```powershell
+    Remove-Item -Path "HKCU:\SOFTWARE\Policies\Claude" -Recurse -Force
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+## 10. 安全规范
+
+<Callout type="warning">
+- API Key 等同于密码；不要写入公开文档、截图或 Git 仓库
+- 导出的 `.reg` / `.mobileconfig` / `.json` 文件可能包含明文 Key，应仅短期保存
+- 如果 Key 被复制到聊天、截图、日志或仓库，应立即作废并重新生成
+- 团队共享配置时，只共享步骤和占位符，不共享真实密钥
+</Callout>
+
+## 11. 最终推荐配置
+
+| 字段 | 值 |
+|---|---|
+| `Gateway base URL` | `https://claude-code.club/api` |
+| `Gateway API key` | 你的有效 API Key |
+| `Gateway auth scheme` | `bearer` |
+| `Gateway extra headers` | 留空 |
+
+Windows 和 macOS 都优先使用 **`Apply locally`**；只有在本地应用失败、需要批量部署或需要备份配置时，才导出对应系统的配置文件。
+
+## 12. 参考资料
+
+- [获取 API Key](/getting-started/get-api-key) — claude-code.club API Key 申请流程
+- [配置 Base URL 和 Auth Token](/getting-started/faq/config-baseurl-authtoken) — Claude Code CLI 视角的三种配置方式
+- [Claude Desktop 第三方推理 / Gateway 配置文档](https://claude.com/docs/cowork/3p/configuration)
+- [Claude Desktop 安装说明](https://support.claude.com/en/articles/10065433-install-claude-desktop)

--- a/pages/getting-started/faq/index.mdx
+++ b/pages/getting-started/faq/index.mdx
@@ -46,6 +46,12 @@ import { Cards, Callout } from 'nextra/components'
   >
     用 Claude Code 作为前端 Agent，搭配 GPT 模型作为后端
   </Cards.Card>
+  <Cards.Card
+    title="Claude Desktop 第三方 Gateway 配置"
+    href="/getting-started/faq/claude-desktop-gateway"
+  >
+    在 Claude Desktop（GUI 客户端）中接入 CC Club Gateway，Win / macOS 完整指南
+  </Cards.Card>
 </Cards>
 
 <Callout type="info">

--- a/pages/getting-started/pricing.mdx
+++ b/pages/getting-started/pricing.mdx
@@ -1,358 +1,165 @@
 ---
 title: 套餐和计费规则
-description: 详细了解 CC Club 的套餐选项和 Claude 官方的计费规则，包括用量限制、会话窗口、周限等关键信息
+description: CC Club 套餐价格、模型倍率、合汇率与周额度规则详解
 tocDepth: 3
 ---
 
-import { Callout, Table } from 'nextra/components'
-import InfoTooltip from '@/components/InfoTooltip'
+import { Callout } from 'nextra/components'
 
 # 套餐和计费规则
 
 <Callout type="warning">
-**友情提示：**   
-严禁多人共享同一 Key。共用 Key 会触发上游风控，导致账号被封禁。近期因共享行为导致封号频率明显上升，已严重影响整体稳定性。如因共用 Key 导致账号异常或封禁，后果需自行承担。
+**友情提示：** 严禁多人共享同一 Key。多人共享可能导致账号风控、额度异常或服务中断。
 </Callout>
 
-本页将帮助你全面了解 CC Club 提供的各种套餐选项，及详细的用量限制规则。
+## CC Club 套餐价格
 
-## CC Club 的计费规则
+CC Club 套餐由「**套餐周额度**」和「**模型倍率**」共同决定实际可使用量。不同模型系列的官方成本不同，会按不同倍率消耗套餐周额度。
+
+| 项目 | Free | Pro | Max | Ultra |
+|---|---|---|---|---|
+| 适合用户 | 简单尝鲜 | 中度使用 | 高强度使用 | 超高强度使用 |
+| 我们的价格 | 免费 | ¥169/月 | ¥799/月 | ¥2499/月 |
+| 窗口限制 | 7 USD/周 | 7 USD/5 小时 | 35 USD/5 小时 | 150 USD/5 小时 |
+| 每周额度 | - | 45 USD/周 | 210 USD/周 | 750 USD/周 |
+| 可用时段 | 全天可用 | 全天可用 | 全天可用 | 全天可用 |
+| 对应官方套餐 | - | Claude Pro | Claude Max 5X | Claude Max 20X |
+| 套餐特权 | - | - | 独享 Key & 高速通道 | 独享 Key & 高速通道 |
+| 服务支持 | 社区支持 | 工单优先处理 | 企微快速响应 | 架构师 1 对 1 |
+
+## 模型倍率与合汇率
+
+不同模型系列在不同套餐下对应不同的倍率和合汇率。格式为：倍率，合汇率。
+
+| 模型系列 | Pro | Max | Ultra |
+|---|---|---|---|
+| Anthropic Claude | 1.5x，1.33CNY/USD | 1.5x，1.33CNY/USD | 1.5x，1.17CNY/USD |
+| OpenAI CodeX | 0.6x，0.53CNY/USD | 0.6x，0.53CNY/USD | 0.6x，0.47CNY/USD |
+| Google Gemini | 0.6x，0.53CNY/USD | 0.6x，0.53CNY/USD | 0.6x，0.47CNY/USD |
 
 <Callout type="info">
-CC Club 严格参考美国 Anthropic [官方套餐政策](#claude-官方的计费规则)的，保证用量比 Anthropic 只多不少。
+免费体验套餐暂不展示固定合汇率。
 </Callout>
 
-CC Club 提供多个档位的套餐，满足不同强度的使用需求：
+## 什么是模型倍率？
 
-<Table>
-  <thead>
-    <tr>
-      <th style={{width: '14%'}}></th>
-      <th style={{width: '20%'}}>Free</th>
-      <th style={{width: '22%'}}>Pro</th>
-      <th style={{width: '22%'}}>Max</th>
-      <th style={{width: '22%'}}>Ultra</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>适合用户</strong></td>
-      <td>简单尝鲜</td>
-      <td>每天 4{'~'}5 小时中度使用</td>
-      <td>每天 8{'~'}10 小时高强度使用（满足 95% 的程序员）</td>
-      <td>肆无忌惮的高强度使用</td>
-    </tr>
-    <tr>
-      <td><strong>我们的价格</strong></td>
-      <td><strong>免费</strong></td>
-      <td><strong>¥169/月</strong></td>
-      <td><strong>¥799/月</strong></td>
-      <td><strong>¥2499/月</strong></td>
-    </tr>
-     <tr>
-      <td><strong>可用token价值</strong></td>
-      <td>7美元/周</td>
-      <td>7美元/5小时</td>
-      <td>35美元/5小时</td>
-      <td>150美元/5小时</td>
-    </tr>
-     <tr>
-      <td><strong>周用量限制<InfoTooltip content="每周的用量限制，超过此用量需要等到下一个周重置用量。" /></strong></td>
-      <td>-</td>
-      <td>70美金/周</td>
-      <td>280美金/周</td>
-      <td>1000美金/周</td>
-    </tr>
-    <tr>
-      <td><strong>可用消息数</strong><InfoTooltip content="消息数是指用户在 claude code 界面中实际发出的自然语言消息数量。此数量仅作人工参考。系统不以此数量做限制，而主要以「可用token价值」作为判断依据。" /></td>
-      <td>45消息/周</td>
-      <td>45消息/5小时</td>
-      <td>225消息/5小时</td>
-      <td>900+消息/5小时</td>
-    </tr>
-   
-    <tr>
-      <td><strong>可用请求数</strong><InfoTooltip content="实际调用 claude 大模型的网络请求数量。此数量仅作人工参考。系统不以此数量做限制，而主要以「可用token价值」作为判断依据。" /></td>
-      <td>5000次/周</td>
-      <td>5000次/5小时</td>
-      <td>5000次/5小时</td>
-      <td>10000次/5小时</td>
-    </tr>
-    
-    <tr>
-      <td><strong>可用时段</strong></td>
-      <td>全天可用</td>
-      <td>全天可用</td>
-      <td>全天可用</td>
-      <td>全天可用</td>
-    </tr>
-    <tr>
-      <td><strong>对应官方套餐</strong></td>
-      <td>-</td>
-      <td>Pro</td>
-      <td>Max 5X</td>
-      <td>Max 20X</td>
-    </tr>
-    <tr>
-      <td><strong>Claude Sonnet 4.5</strong></td>
-      <td>✅可用</td>
-      <td>✅可用</td>
-      <td>✅可用</td>
-      <td>✅可用+更高优先级</td>
-    </tr>
-    <tr>
-      <td><strong>Claude Opus 4.5</strong></td>
-      <td>✅可用</td>
-      <td>✅可用</td>
-      <td>✅可用</td>
-      <td>✅可用+更高优先级</td>
-    </tr>
-    <tr>
-      <td><strong>Gemini Flash</strong></td>
-      <td>✅可用</td>
-      <td>✅可用</td>
-      <td>✅可用</td>
-      <td>✅可用+更高优先级</td>
-    </tr>
-    <tr>
-      <td><strong>Gemini Pro</strong></td>
-      <td>✅可用</td>
-      <td>✅可用</td>
-      <td>✅可用</td>
-      <td>✅可用+更高优先级</td>
-    </tr>
-    <tr>
-      <td><strong>CodeX</strong></td>
-      <td>✅可用</td>
-      <td>✅可用</td>
-      <td>✅可用</td>
-      <td>✅可用+更高优先级</td>
-    </tr>
-  </tbody>
-</Table>
+模型倍率用于计算不同模型系列对套餐周额度的消耗。
 
-### 用量承诺
+计算公式：
+
+```text
+模型官方原价消耗 × 模型倍率 = 实际消耗的周额度
+```
+
+倍率越低，额度越耐用；倍率越高，额度消耗越快。
+
+以 Max 套餐为例，Max 的周额度为 210 USD。
+
+如果全部使用 OpenAI CodeX 或 Google Gemini：
+
+```text
+210 ÷ 0.6 = 350
+```
+
+也就是说，Max 套餐每周最多可以使用约 350 USD 官方原价的 OpenAI CodeX / Google Gemini 模型额度。
+
+如果全部使用 Anthropic Claude：
+
+```text
+210 ÷ 1.5 = 140
+```
+
+也就是说，Max 套餐每周最多可以使用约 140 USD 官方原价的 Anthropic Claude 模型额度。
+
+如果一周内混合使用多个模型，系统会分别按模型倍率计算后相加。
+
+例如 OpenAI CodeX 使用 100 USD，Anthropic Claude 使用 50 USD：
+
+```text
+100 × 0.6 + 50 × 1.5 = 135
+```
+
+最终会从 Max 套餐的 210 USD 周额度中扣除 135 USD。
+
+## 什么是合汇率？
+
+合汇率表示：在套餐用满的情况下，用户每使用 1 USD 官方原价模型额度，折合需要多少人民币。
+
+以 Max 套餐为例：
+
+| 模型系列 | 合汇率 | 含义 |
+|---|---|---|
+| OpenAI CodeX / Google Gemini | 0.53CNY/USD | 使用价值 1 USD 的 OpenAI CodeX / Google Gemini 模型额度，折合人民币约 0.53 元 |
+| Anthropic Claude | 1.33CNY/USD | 使用价值 1 USD 的 Anthropic Claude 模型额度，折合人民币约 1.33 元 |
 
 <Callout type="info">
-* **Free 套餐**：这是免费体验套餐，CC Club 不对其可用量做承诺。会随着 Claude 官方价格调整和账号封锁策略来调整，甚至有可能临时取消 Free 套餐。  
-* **付费套餐**：CC Club 承诺保证您已经支付的订阅时长内，按照您下单时的用量履约。就算 Claude 官方涨价，我们也不会对已经支付的订阅用户改变用量限制。
-
+合汇率不是实时美元汇率，也不是银行汇率。它是根据套餐价格、套餐周额度和模型倍率综合计算出来的套餐折算单价，仅用于理解套餐用满时的成本参考。
 </Callout>
 
-
-### 定价原则
-
-CC Club 采用**成本定价**策略，维持团队基本经营，让更多开发者能够以合理的价格使用 Claude Code。
-
-
-
-## Claude 官方的计费规则
-
-<Callout type="info">
-CC Club 的套餐规格严格与 Anthropic 官方的套餐规格对齐，用量只多不少。
-</Callout>
-
-以下是 Anthropic 官方各个套餐的详细对比：
-
-<Table>
-  <thead>
-    <tr>
-      <th style={{width: '15%'}}>套餐项目</th>
-      <th style={{width: '24%'}}>Pro</th>
-      <th style={{width: '28%'}}>Max 5X</th>
-      <th style={{width: '28%'}}>Max 20X</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>官方价格</strong></td>
-      <td>$20/月</td>
-      <td>$100/月</td>
-      <td>$200/月</td>
-    </tr>
-    <tr>
-      <td><strong>适用场景</strong></td>
-      <td>小型代码库的轻度编码工作</td>
-      <td>经常使用Claude处理各种任务</td>
-      <td>每天使用Claude协作处理大部分任务</td>
-    </tr>
-    <tr>
-      <td><strong>使用量倍数</strong></td>
-      <td>基准用量</td>
-      <td>Pro的5倍</td>
-      <td>Pro的20倍</td>
-    </tr>
-    <tr>
-      <td><strong>可用消息数</strong><InfoTooltip content="消息数是指用户在 claude code 界面中实际发出的自然语言消息数量" /></td>
-      <td>10-40个提示/5小时</td>
-      <td>50-200个提示/5小时</td>
-      <td>200-800个提示/5小时</td>
-    </tr>
-    <tr>
-      <td><strong>可用token价值<InfoTooltip content="官方未公布此数据，此数据由行业实际测量所得" /></strong></td>
-      <td>7美元/5小时</td>
-      <td>25-30美元/5小时</td>
-      <td>100-120美元/5小时</td>
-    </tr>
-    <tr>
-      <td><strong>周用量限制<InfoTooltip content="官方未公布此数据，此数据由行业实际测量所得" /></strong></td>
-      <td>32美元/周</td>
-      <td>150美元/周</td>
-      <td>600美元/周</td>
-    </tr>
-    <tr>
-      <td><strong>每周 Sonnet 4.5 时长</strong></td>
-      <td>40-80小时</td>
-      <td>140-280小时</td>
-      <td>240-480小时</td>
-    </tr>
-    <tr>
-      <td><strong>Claude 4.5 Sonnet</strong></td>
-      <td>✅支持</td>
-      <td>✅支持</td>
-      <td>✅支持</td>
-    </tr>
-    <tr>
-      <td><strong>限制重置</strong></td>
-      <td>每5小时</td>
-      <td>每5小时</td>
-      <td>每5小时</td>
-    </tr>
-    <tr>
-      <td><strong>上下文窗口</strong></td>
-      <td>200K</td>
-      <td>200K</td>
-      <td>200K</td>
-    </tr>
-    <tr>
-      <td><strong>最适合</strong></td>
-      <td>小型代码库(&lt;1000行代码)的轻度工作</td>
-      <td>日常使用较大代码库</td>
-      <td>高级用户、大型代码库</td>
-    </tr>
-  </tbody>
-</Table>
-
-<Callout type="info">
-消息数量会根据消息长度（包括附件）、当前对话长度、使用的模型或功能而有所不同。
-</Callout>
+## 倍率调整说明
 
 <Callout type="warning">
-虽然 Max 套餐提供扩展的使用限制，但**上下文窗口大小**在所有计划中都保持在 **200K**。这意味着您可以发送更多消息，但单个聊天的长度与其他计划具有相同的上下文窗口限制。
+由于大模型市场价格、供应情况和官方计费规则可能发生变化，CC Club 的模型倍率和合汇率也可能随之调整。如发生倍率调整，我们会提前 3 天通知用户。
 </Callout>
-
-### 影响使用量的因素
-
-以下因素会影响您的实际使用量：
-
-1. **代码库大小**：更大的代码库会消耗更多使用量
-2. **用户设置**：如自动接受模式等
-3. **并行使用**：同时运行多个 Claude Code 实例会更快达到限制
-4. **模型选择**：Opus 4 比 Sonnet 4 消耗更多使用量
-5. **消息长度**：更长的消息和附件会消耗更多使用量
-6. **对话长度**：更长的对话会消耗更多使用量
-
-
-
 
 ## 什么是会话窗口限制？
 
-**会话窗口限制**是指在一个固定时间段内（通常是 5 小时）您可以使用的最大消息数或 token 数。
+会话窗口限制是指在一个固定时间窗口内可消耗的额度上限。
 
-### 工作原理
+例如 Max 套餐的窗口限制为 35 USD/5 小时，表示在任意 5 小时窗口内，最多可消耗 35 USD 周额度。
 
-1. **5 小时滚动窗口**：从您开始使用的时间点开始计算，每 5 小时自动重置
-2. **动态计算**：限制基于您发送的消息数量、对话总长度、文件附件大小等因素
-3. **达到限制**：如果在 5 小时内用完限制，需要等待窗口重置才能继续使用
+窗口限制和每周额度是两个不同概念：
 
-### 实际可用量
+- **窗口限制**：控制短时间内的使用强度
+- **每周额度**：控制一周内的总使用量
 
-根据社区实际测量经验,各套餐的 Token 价值限制为:
+## 什么是周额度？
 
-- **Pro 套餐**:5 小时内约 **$6** 的 token 使用价值
-- **Max 5X 套餐**:5 小时内约 **$30** 的 token 使用价值
-- **Max 20X 套餐**:5 小时内约 **$120** 的 token 使用价值
+周额度是套餐每周可消耗的总额度。
 
-### 示例
+| 套餐 | 每周额度 |
+|---|---|
+| Pro | 45 USD/周 |
+| Max | 210 USD/周 |
+| Ultra | 750 USD/周 |
 
-假设您下午 1:00 开始使用 Claude Code：
-- 如果您使用量较大，在下午 3:00 用完了 5 小时限制
-- 您需要等到下午 6:00（5 小时后）才能继续使用
-- 系统会在接近限制时显示警告
+不同模型系列会根据倍率消耗周额度，因此实际可使用的模型官方原价额度会不同。以 Max 套餐 210 USD 周额度为例：
 
-<Callout type="info">
-Claude Code 会在您接近使用限制时显示警告，帮助您合理安排工作。
-</Callout>
-
-
-
-## 什么是周限？
-
-**周限**（Weekly Limit）是 Claude 官方为防止滥用而设置的额外限制机制。
-
-### 基本原理
-
-根据社区讨论和实际使用经验：
-
-1. **双层限制系统**：
-   - **5 小时窗口限制**：短期使用限制，每 5 小时重置
-   - **1 周窗口限制**：长期使用限制，1 周内的总使用量
-
-3. **累积计算**：
-   - 周限会累积计算一周内的所有使用量
-   - 如果连续高强度使用，可能会触发周限
-   - 周限重置后才能继续使用
-
-### 实际使用体验
-
-根据社区实际测量经验,各套餐的周限 Token 价值限制为:
-
-- **Pro 套餐**:1 周约 **$32** 的 token 使用价值
-- **Max 5X 套餐**:1 周约 **$150** 的 token 使用价值
-- **Max 20X 套餐**:1 周约 **$600** 的 token 使用价值
-
-社区用户反馈：
-
-- 使用 Opus 4 时更容易达到限制（因为成本更高）
-- 同时运行多个 Claude Code 实例会加速达到限制
-- 大多数正常使用的用户不会触发周限
-- 高强度持续使用才可能遇到周限
-
-<Callout type="warning">
-**CC Club 当前政策**：迫于成本压力，目前 CC Club 已引入周限规则。额度比官方略高，参考上文介绍。
-</Callout>
-
-
+- 全部使用 OpenAI CodeX / Google Gemini：最多约 **350 USD** 官方原价额度
+- 全部使用 Anthropic Claude：最多约 **140 USD** 官方原价额度
 
 ## 常见问题
 
-### Q: 如果我用超了会怎么样？
+### 倍率越低是不是越划算？
 
-- **不会额外收费**：没有"超额"收费机制
-- **暂时停用**：达到限制后会被暂时切断访问
-- **等待重置**：需要等待相应的时间窗口重置（5 小时或 1 周）
+是的。倍率越低，表示同样使用 1 USD 官方原价模型额度时，消耗的套餐周额度越少。
 
-### Q: Pro 和 Max 的限制有什么区别？
+例如 0.6x 表示使用 1 USD 模型额度，只消耗 0.6 USD 周额度。
 
-主要区别在于使用量倍数：
-- **Pro**：基准使用量
-- **Max 5X**：Pro 的 5 倍
-- **Max 20X**：Pro 的 20 倍
+### 合汇率是美元汇率吗？
 
-此外，Max 套餐可以使用 Opus 4 模型，而 Pro 套餐只能使用 Sonnet 4。
+不是。合汇率不是银行汇率，也不是实时美元兑人民币汇率。
 
-### Q: 如何查看我的当前使用情况？
+它表示在套餐用满的情况下，用户每使用 1 USD 官方原价模型额度，折合需要多少人民币。
 
-在「[自助服务系统](https://customer.claude-code.club/)」中的「[概览](https://customer.claude-code.club/dashboard)」页面，可以查看当前用量。
+### 同时使用多个模型，额度怎么算？
 
+系统会分别按每个模型系列的倍率计算后相加。
 
+例如 OpenAI CodeX 使用 100 USD，Anthropic Claude 使用 50 USD：
 
+```text
+100 × 0.6 + 50 × 1.5 = 135
+```
+
+最终消耗 135 USD 周额度。
+
+### 倍率以后会变化吗？
+
+可能会。由于大模型市场价格和供应情况可能变化，模型倍率和合汇率也可能调整。如发生倍率调整，我们会提前 3 天通知用户。
 
 ## 相关资源
 
 - [获取 API Key](/getting-started/get-api-key)
 - [安装和配置](/getting-started/installation)
 - [常见问题](/getting-started/faq)
-- [Claude 官方文档：Pro 计划使用情况](https://support.claude.com/zh-CN/articles/8324991-%E5%85%B3%E4%BA%8Eclaude%E4%B8%93%E4%B8%9A%E7%89%88%E8%AE%A1%E5%88%92%E4%BD%BF%E7%94%A8%E6%83%85%E5%86%B5)
-- [Claude 官方文档：Max 计划使用情况](https://support.claude.com/zh-CN/articles/11014257-%E5%85%B3%E4%BA%8Eclaude%E7%9A%84max%E8%AE%A1%E5%88%92%E4%BD%BF%E7%94%A8%E6%83%85%E5%86%B5)
-- [Claude 官方文档：在 Pro 或 Max 计划中使用 Claude Code](https://support.claude.com/zh-CN/articles/11145838-%E5%9C%A8%E6%82%A8%E7%9A%84-pro-%E6%88%96-max-%E8%AE%A1%E5%88%92%E4%B8%AD%E4%BD%BF%E7%94%A8-claude-code)

--- a/styles/global.css
+++ b/styles/global.css
@@ -267,3 +267,4 @@ nav a[aria-current="true"] {
 html.dark nav a[aria-current="true"] {
   color: hsl(var(--nextra-primary-hue), var(--nextra-primary-saturation), 60%) !important;
 }
+


### PR DESCRIPTION
 - **套餐计费页改版**（`pages/getting-started/pricing.mdx`）：改为周额度 + 模型倍率 + 合汇率结构，新增 Anthropic Claude / OpenAI CodeX / Google Gemini             
  三系列倍率表，补充「什么是模型倍率/合汇率/周额度」「倍率调整说明」概念章节，移除已过期的旧模型对比表
  - **新增指南**（`pages/getting-started/codex-desktop.mdx`）：Codex Desktop GUI 客户端通过 OpenAI Gateway 接入的完整流程——`config.toml` + `auth.json`              
  最小配置、完全重启策略、macOS `launchctl` 环境变量、`curl` 连通性测试、故障排查、备份恢复                                                                         
  - **新增 FAQ**（`pages/getting-started/faq/claude-desktop-gateway.mdx`）：Claude Desktop GUI 客户端通过 `https://claude-code.club/api` 接入 Gateway
  的完整流程——核心概念与地址选择、检查清单、Configure third-party inference 图形界面、Apply locally vs Export(.reg/.mobileconfig) 备用方案、CLI                     
  环境变量、验证与故障排查、恢复默认配置
    ## 包含的 commit                                                                                                                                                  
   
  - `b587645` Add: Codex Desktop 客户端配置（OpenAI Gateway）指南                                                                                                   
  - `ee9cacc` Update: 套餐和计费规则页改为周额度 + 模型倍率 + 合汇率
  - `b2512f6` Add: Claude Desktop 第三方 Gateway 配置 FAQ                                                                                                           
                                                                                                                                                                    
  ## 测试要点                                                                                                                                                       
                                                                                                                                                                    
  - [ ] `pnpm dev` 本地预览三个页面（pricing / codex-desktop / faq/claude-desktop-gateway）渲染正常                                                                 
  - [ ] 侧边栏顺序符合 `_meta.js` 配置                   
  - [ ] Callout / Steps / Tabs / Table 等 Nextra 组件无报错  